### PR TITLE
[BUGFIX] only include language in dashboard links if necessary

### DIFF
--- a/admin/jqadm/templates/common/page-default.php
+++ b/admin/jqadm/templates/common/page-default.php
@@ -174,7 +174,7 @@ $extParams = array( 'site' => $site, 'lang' => $this->param( 'lang' ) );
 $params = $this->get( 'pageParams', array() );
 $params['resource'] = $this->param( 'resource', 'dashboard' );
 $params['site'] = $this->param( 'site', 'default' );
-$params['lang'] = $this->param( 'lang', 'en' );
+$params['lang'] = $this->param( 'lang', null );
 $params['id'] = $this->param( 'id', '' );
 
 


### PR DESCRIPTION
Currently the language parameter is set to en if
there is none specified which results in language
switch from dashboard to e.g. products if
your locale is not en

Resolves: #2