### PR TITLE
add missing "?" for opening tag

### DIFF
--- a/admin/jqadm/templates/order/item-standard.php
+++ b/admin/jqadm/templates/order/item-standard.php
@@ -284,7 +284,7 @@ $statusList = [
 													<?= $enc->html( $this->translate( 'admin', 'Please select' ) ); ?>
 												</option>
 												<?php foreach( $statusList as $code => $label ) : ?>
-													<option value="<= $code ?>" <?= $selected( $this->get( 'itemData/product/' . $pos . '/order.base.product.status' ), $code ); ?> >
+													<option value="<?= $code ?>" <?= $selected( $this->get( 'itemData/product/' . $pos . '/order.base.product.status' ), $code ); ?> >
 														<?= $enc->html( $label ); ?>
 													</option>
 												<?php endforeach; ?>


### PR DESCRIPTION
Fix typo so that `$code` gets rendered properly.