### PR TITLE
Fixed problem with multisite and superusers

### DIFF
--- a/admin/jqadm/src/Admin/JQAdm/Common/Decorator/Page.php
+++ b/admin/jqadm/src/Admin/JQAdm/Common/Decorator/Page.php
@@ -41,6 +41,9 @@ class Page extends Base
 
 		try {
 			$siteid = $customerManager->getItem( $context->getUserId() )->getSiteId();
+			if(is_null($siteid)) {
+				$siteid = $siteItem->getSiteId();
+			}
 		} catch( \Exception $e ) {
 			$siteid = $siteItem->getSiteId();
 		}


### PR DESCRIPTION
Wrong siteid is being set when a superuser access to any page for other than default site.
The fix involves two things: 
First, superusers's siteid must be set to NULL on database.
Second, Page decorator must use the item siteid in case of null siteid come from the user item