### PR TITLE
Increase z-index of main-navbar

### DIFF
--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -144,7 +144,7 @@
 	.aimeos .main-navbar {
 		position: -webkit-sticky;
 		position: sticky;
-		z-index: 1030;
+		z-index: 1060;
 		top: 0;
 	}
 	.aimeos .item-container .item-actions {


### PR DESCRIPTION
Currently, when the `products` page is open, the items-per-page counter of the top pagination item remains visible over the `main-navbar`, when the page is scrolled. 

![Screen Shot 2020-06-17 at 12 23 06](https://user-images.githubusercontent.com/213803/85007418-cd233b80-b15b-11ea-9df9-9b1df999874d.png)

Raising the z-index of the class `.main-navbar` fixes this issue.

(The confirmation modal that appears, when a product was edited, remains visible.)