### PR TITLE
Fix left-margin of multiline category names

### DIFF
--- a/admin/jqadm/themes/default/jqtree.css
+++ b/admin/jqadm/themes/default/jqtree.css
@@ -65,6 +65,7 @@ ul.jqtree-tree .jqtree-title {
   color: #1C4257;
   vertical-align: middle;
   margin-left: 1.75em;
+  display: inline-block;
 }
 
 ul.jqtree-tree .jqtree-title.jqtree-title-folder {


### PR DESCRIPTION

When a category name breaks, the second (and following) lines to not respect the left margin due to the fact that `span` is by definition set to `display: inline`:

![long-category-name-before-fix](https://user-images.githubusercontent.com/213803/85009007-0c528c00-b15e-11ea-81cf-bdc6b1b0a3e5.png)

Adding `display: inline-block` to the class `.ul.jqtree-tree .jqtree-title` forces all lines to respect the left margin:

![long-category-name-after-fix](https://user-images.githubusercontent.com/213803/85009043-18d6e480-b15e-11ea-9030-2b08b0477441.png)
