### PR TITLE
Increase z-index of main-navbar

### DIFF
--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -144,7 +144,7 @@
 	.aimeos .main-navbar {
 		position: -webkit-sticky;
 		position: sticky;
-		z-index: 1030;
+		z-index: 1041;
 		top: 0;
 	}
 	.aimeos .item-container .item-actions {


### PR DESCRIPTION

On `products` page, the top pagination's `items per page` (z-index: 1040) is visible, when the page is scrolled.
Increasing the z-index of `.main-navbar` from currently 1030 to 1041 fixes this issue. 1041 is chosen in order not to get in conflict with modals (delete, confirm... all seem to be at 1050).

Current behaviour on scroll-down:
![Screen Shot 2020-06-17 at 12 22 54](https://user-images.githubusercontent.com/213803/85010668-b03d3700-b160-11ea-9340-43737504e3c4.png)
![Screen Shot 2020-06-17 at 12 23 06](https://user-images.githubusercontent.com/213803/85010700-bb906280-b160-11ea-8120-0e623f989be9.png)

Check modal after fix:
![Screen Shot 2020-06-18 at 12 37 45](https://user-images.githubusercontent.com/213803/85010754-d236b980-b160-11ea-80be-108ded0ee2b1.png)
