### PR TITLE
Improve slide-out of tree-menu

### DIFF
--- a/admin/jqadm/themes/default/sidebar.css
+++ b/admin/jqadm/themes/default/sidebar.css
@@ -142,6 +142,7 @@
 	position: fixed;
 	display: block;
 	top: 0;
+	left: 3rem;
 	bottom: 0;
 	z-index: -1;
 	width: 15rem;
@@ -151,15 +152,19 @@
 	background: #283038;
 	box-shadow: 0 0 3px #000;
 	transform: translateX(-100%);
-	transition-property: transform;
-	transition-timing-function: ease-in-out;
-	transition-duration: .3s;
+	transition-property: transform, visibility, left;
+	transition-timing-function: ease-in-out, ease, ease-in-out;
+	transition-duration: 0.3s, 0s, 0.3s;
+	transition-delay: 0s, 0.3s, 0s;
 }
 
 .aimeos .sidebar-menu li:hover .tree-menu {
 	transform: translateX(0);
 	visibility: visible;
-	left: 3rem;
+	transition-property: transform, visibility, left;
+	transition-timing-function: ease-in-out, ease, ease-in-out;
+	transition-duration: .3s, 0s, .3s;
+	transition-delay: 0s, 0s, 0s;
 }
 
 .aimeos .sidebar-menu .tree-menu {


### PR DESCRIPTION
Currently, the tree-menu (sub menu of locales and types) disappears immediately as soon as there is no `:hover` applied anymore. This is due to the fact that on "hover-out" `visibility` is immediately set to `hidden`. In order to circumvent that problem, it is necessary to assign a `delay` value to the `visibility` param of the same duration as `transform`. Then, this very delay-value has to be set to 0 on the `:hover` pseudo-class on `li`.

Furthermore, the "slide-out" motion requires the attribute `left` to be set to 3rem (smallest [mobile] value) on the `.tree-menu` class itself, not in its `:hover` pseudo-class, and it must be included in the transition animation, too, otherwise there is a nasty abrupt jump in the animation.

Tested on Chrome, Safari, Firefox, Brave. Not IE/Edge!

Question: in `@media (min-width: 992px) {` there is `.aimeos .sidebar-menu > li:hover > .tree-menu {` as well as `.aimeos .sidebar-menu li:hover .tree-menu {`. Why? In my tests the first one worked fine.