### PR TITLE
For Discussion: Improved mobile layout  main content area

### DIFF
--- a/admin/jqadm/templates/common/partials/navsearch-standard.php
+++ b/admin/jqadm/templates/common/partials/navsearch-standard.php
@@ -36,6 +36,12 @@ $enc = $this->encoder();
 
 
 ?>
+<div id="js--toggle-search" class="toggle-search">
+	<span class="icon search"></span>
+	<span class="icon chevron"></span>
+	<span class="hidden">Show/hide search.</span>
+</div>
+
 <form class="form-inline" method="POST" action="<?= $enc->attr( $this->url( $target, $controller, $action, $params, [], $config ) ); ?>">
 	<?= $this->csrf()->formfield(); ?>
 

--- a/admin/jqadm/templates/common/partials/navsearch-standard.php
+++ b/admin/jqadm/templates/common/partials/navsearch-standard.php
@@ -38,7 +38,6 @@ $enc = $this->encoder();
 ?>
 <div id="js--toggle-search" class="toggle-search">
 	<span class="icon search"></span>
-	<span class="icon chevron"></span>
 	<span class="hidden">Show/hide search.</span>
 </div>
 

--- a/admin/jqadm/templates/common/partials/pagination-standard.php
+++ b/admin/jqadm/templates/common/partials/pagination-standard.php
@@ -97,7 +97,8 @@ $enc = $this->encoder();
 			</li><!--
 			--><li class="page-item disabled">
 				<a class="page-link" tabindex="<?= $this->get( 'tabindex', 1 ); ?>" href="#">
-					<?= $enc->html( sprintf( $this->translate( 'admin', 'Page %1$d of %2$d' ), $pageCurrent, $pageTotal ) ); ?>
+					<span class="d-none d-lg-block"><?= $enc->html( sprintf( $this->translate( 'admin', 'Page %1$d of %2$d' ), $pageCurrent, $pageTotal ) ); ?></span>
+					<span class="d-lg-none"><?= $enc->html( sprintf( '%1$d/%2$d', $pageCurrent, $pageTotal ) ); ?></span>
 				</a>
 			</li><!--
 			--><li class="page-item <?= ( $next === null ? 'disabled' : '' ) ?>">

--- a/admin/jqadm/templates/common/partials/pagination-standard.php
+++ b/admin/jqadm/templates/common/partials/pagination-standard.php
@@ -121,7 +121,7 @@ $enc = $this->encoder();
 				 tabindex="<?= $this->get( 'tabindex', 1 ); ?>" aria-haspopup="true" aria-expanded="false">
 				<?= $limit; ?> <span class="caret"></span>
 			</button>
-			<ul class="dropdown-menu">
+			<ul class="dropdown-menu dropdown-menu-right">
 				<li class="dropdown-item">
 					<a href="<?php $pLimit['limit'] = 25; echo $enc->attr( $this->url( $target, $controller, $action, $pgroup( $pLimit, $group ) + $params, $fragment, $config ) ); ?>"
 						tabindex="<?= $this->get( 'tabindex', 1 ); ?>">25</a>

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -831,6 +831,8 @@ Aimeos.Nav = {
 		this.toggleFormItems();
 		this.toggleNavItems();
 		this.toggleMenu();
+		this.toggleNavItemsTexts();
+		this.toggleSearch();
 	},
 
 
@@ -957,6 +959,22 @@ Aimeos.Nav = {
 				window.sessionStorage.setItem('aimeos/jqadm/item/form', 0);
 			}
 		});
+	},
+
+
+	toggleNavItemsTexts : function() {
+
+		$('#js--toggle-nav-items-text').on('click', function() {
+			document.body.classList.toggle('js--show-nav-items-texts');
+		})
+	},
+
+
+	toggleSearch : function() {
+
+		$('#js--toggle-search').on('click', function() {
+			document.body.classList.toggle('js--show-search');
+		})
 	}
 };
 

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -831,7 +831,6 @@ Aimeos.Nav = {
 		this.toggleFormItems();
 		this.toggleNavItems();
 		this.toggleMenu();
-		this.toggleNavItemsTexts();
 		this.toggleSearch();
 	},
 
@@ -959,14 +958,6 @@ Aimeos.Nav = {
 				window.sessionStorage.setItem('aimeos/jqadm/item/form', 0);
 			}
 		});
-	},
-
-
-	toggleNavItemsTexts : function() {
-
-		$('#js--toggle-nav-items-text').on('click', function() {
-			document.body.classList.toggle('js--show-nav-items-texts');
-		})
 	},
 
 

--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -10,6 +10,14 @@
 	text-align: center;
 }
 
+.page-limit .dropdown-menu {
+	min-width: 5rem;
+}
+
+.page-limit .dropdown-menu .dropdown-item {
+	text-align: center
+}
+
 @media (max-width: 992px) {
 
 	.aimeos .list-page {
@@ -21,14 +29,6 @@
 	.aimeos .list-page .page-limit,
 	.aimeos .list-page .pagination {
 		margin: 0;
-	}
-
-	.aimeos .list-page .page-limit {
-		order: 1;
-	}
-
-	.aimeos .list-page .pagination {
-		order: 2;
 	}
 
 	.aimeos .list-page .btn {

--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -4,110 +4,17 @@
  */
 
 
-
-/** Main Navbar **/
-
-.aimeos .main-navbar {
- 	min-height: 3rem;
-}
-
-.aimeos .main-navbar span.placeholder {
-	display: inline-block;
-	height: 35px;
-}
-
-
-/** Main navbar search toggle **/
-
-@media (max-width: 992px) {
-	.aimeos .js--toggle-search {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		flex-wrap: nowrap;
-		position: absolute;
-		top: 14px;
-		right: 26px;
-		width: 30px;
-		height: 24px;
-		cursor: pointer;
-		transition: color .3s;
-	}
-
-	.aimeos .js--toggle-search:hover {
-		color: #333;
-	}
-
-	.aimeos .js--toggle-search .icon {
-		font: normal normal normal 14px/1 FontAwesome;
-		color: #90A0B0;
-		display: block;
-	}
-
-	.aimeos .js--toggle-search .icon.chevron {
-		font-size: 10px;
-		color: #ccc;
-	}
-
-	.aimeos .js--toggle-search .icon.search:before {
-		content: "\f002"
-	}
-
-	.aimeos .js--toggle-search .icon.chevron:before {
-		content: "\f078";
-	}
-}
-
-@media (min-width: 992px) {
-	.aimeos .js--toggle-search {
-		display: none;
-	}
-}
-
-
-/* Enable horizontal scrolling for table content  */
-
-.aimeos form.list {
-	overflow-x: auto;
-	margin-bottom: 1rem;
-	padding-bottom: 0.5rem;
-}
-
-
 /* Pagination */
 
 .aimeos .list-page {
 	text-align: center;
 }
 
-.aimeos .list-page .pagination {
-	display: inline-block;
-	margin: 1rem;
-}
-
-.aimeos .list-page .page-item {
-	display: inline-block;
-	text-align: center;
-}
-
-.aimeos .list-page .page-limit {
-	vertical-align: top;
-	margin: 1rem;
-}
-
-.aimeos .list-page .btn {
-	padding: 0.4rem 1rem;
-}
-
-.aimeos .list-page .page-link {
-	min-width: 3rem;
-}
-
 @media (max-width: 992px) {
 
- 	.aimeos .list-page {
-		margin-bottom: 0.75rem;
+	.aimeos .list-page {
 		display: flex;
+		margin-bottom: 1rem;
 		justify-content: space-between;
 	}
 
@@ -128,8 +35,36 @@
 		padding-left: 0.5rem;
 		padding-right: 0.5rem;
 	}
+
+	.aimeos .list-page .page-link {
+		min-width: 2rem;
+	}
 }
 
+@media (min-width: 992px) {
+	.aimeos .list-page .pagination {
+		display: inline-block;
+		margin: 1rem;
+	}
+
+	.aimeos .list-page .page-item {
+		display: inline-block;
+		text-align: center;
+	}
+
+	.aimeos .list-page .page-limit {
+		vertical-align: top;
+		margin: 1rem;
+	}
+
+	.aimeos .list-page .btn {
+		padding: 0.4rem 1rem;
+	}
+
+	.aimeos .list-page .page-link {
+		min-width: 3rem;
+	}
+}
 
 
 /** Tree view */
@@ -168,6 +103,14 @@
 	content: "\f068";
 }
 
+
+/* Enable horizontal scrolling for table content  */
+
+.aimeos form.list {
+	overflow-x: auto;
+	margin-bottom: 1rem;
+	padding-bottom: 0.5rem;
+}
 
 
 /* Item listing */

--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -5,6 +5,75 @@
 
 
 
+/** Main Navbar **/
+
+.aimeos .main-navbar {
+ 	min-height: 3rem;
+}
+
+.aimeos .main-navbar span.placeholder {
+	display: inline-block;
+	height: 35px;
+}
+
+
+/** Main navbar search toggle **/
+
+@media (max-width: 992px) {
+	.aimeos .js--toggle-search {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: nowrap;
+		position: absolute;
+		top: 14px;
+		right: 26px;
+		width: 30px;
+		height: 24px;
+		cursor: pointer;
+		transition: color .3s;
+	}
+
+	.aimeos .js--toggle-search:hover {
+		color: #333;
+	}
+
+	.aimeos .js--toggle-search .icon {
+		font: normal normal normal 14px/1 FontAwesome;
+		color: #90A0B0;
+		display: block;
+	}
+
+	.aimeos .js--toggle-search .icon.chevron {
+		font-size: 10px;
+		color: #ccc;
+	}
+
+	.aimeos .js--toggle-search .icon.search:before {
+		content: "\f002"
+	}
+
+	.aimeos .js--toggle-search .icon.chevron:before {
+		content: "\f078";
+	}
+}
+
+@media (min-width: 992px) {
+	.aimeos .js--toggle-search {
+		display: none;
+	}
+}
+
+
+/* Enable horizontal scrolling for table content  */
+
+.aimeos form.list {
+	overflow-x: auto;
+	margin-bottom: 1rem;
+	padding-bottom: 0.5rem;
+}
+
+
 /* Pagination */
 
 .aimeos .list-page {
@@ -32,6 +101,33 @@
 
 .aimeos .list-page .page-link {
 	min-width: 3rem;
+}
+
+@media (max-width: 992px) {
+
+ 	.aimeos .list-page {
+		margin-bottom: 0.75rem;
+		display: flex;
+		justify-content: space-between;
+	}
+
+	.aimeos .list-page .page-limit,
+	.aimeos .list-page .pagination {
+		margin: 0;
+	}
+
+	.aimeos .list-page .page-limit {
+		order: 1;
+	}
+
+	.aimeos .list-page .pagination {
+		order: 2;
+	}
+
+	.aimeos .list-page .btn {
+		padding-left: 0.5rem;
+		padding-right: 0.5rem;
+	}
 }
 
 
@@ -575,12 +671,6 @@
 	padding: 0;
 	opacity: 0;
 	left: 0;
-}
-
-
-.aimeos .main-navbar span.placeholder {
-	display: inline-block;
-	height: 35px;
 }
 
 .aimeos .list-log .list-items td {

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -11,8 +11,6 @@
 	align-items: center;
 	justify-content: space-between;
 	min-height: 3rem;
-
-	/* text-align: right; */
 	background-color: #F8F8F8;
 	margin-bottom: 1rem;
 	padding: 0.5rem;
@@ -62,27 +60,12 @@
 		display: block;
 	}
 
-	.aimeos .toggle-search .icon.chevron {
-		font-size: 10px;
-		color: #4090C0;
-	}
-
 	.aimeos .toggle-search .icon.search:before {
 		content: "\f002"
 	}
-
-	/* open */
-	.aimeos .toggle-search .icon.chevron:before {
-		content: "\f078";
-	}
-
-	/* close */
-	.js--show-search .aimeos .toggle-search .icon.chevron:before {
-		content: "\f077";
-	}
 }
 
-@media (min-width: 992px) {
+@media (min-width: 768px) {
 	.aimeos .toggle-search {
 		display: none;
 	}
@@ -158,36 +141,66 @@
 	max-width: 4rem;
 }
 
-@media (max-width: 992px) {
+@media (max-width: 767px) {
 
 	.aimeos .main-navbar .form-inline {
 		flex-wrap: nowrap;
 		align-items: center;
 		justify-content: flex-end;
-		position: fixed;
-		/*
-		TODO: fixed elements don't respect the scrollbar, so its width
-		need to be included on desktops: 32px
-		*/
-		right: 15px;
-		left: calc(3rem + 15px);
+		position: absolute;
+		right: 0;
+		left: 3rem;
+		max-width: 100%;
 		background: white;
 		padding: 0.25rem;
 		border-radius: 4px;
-		box-shadow: 0 0 4px rgba(0, 0, 0, .35);
+		box-shadow: 0 0 4px rgba(20, 20, 20, .35);
 		white-space: nowrap;
-
-		transition: top .3s ease-in-out, z-index .3s, visibility .3s ease .3s;
-		top: -36px;
 		z-index: -1;
 		visibility: hidden;
+		-webkit-transition: z-index .3s,
+			visibility .3s ease .3s,
+			-webkit-transform .3s ease-in-out;
+		transition: z-index .3s,
+			visibility .3s ease .3s,
+			-webkit-transform .3s ease-in-out;
+		-o-transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility .3s ease .3s;
+		transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility .3s ease .3s;
+		transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility .3s ease .3s,
+			-webkit-transform .3s ease-in-out;
+		-webkit-transform: translateY(-48px);
+		-ms-transform: translateY(-48px);
+		transform: translateY(-48px);
 	}
 
 	.js--show-search .aimeos .main-navbar .form-inline {
 		visibility: visible;
-		top: 62px;
 		z-index: 2000;
-		transition: top .3s ease-in-out, z-index .3s, visibility 0s ease 0s;
+		-webkit-transform: translateY(58px);
+		-ms-transform: translateY(58px);
+		transform: translateY(58px);
+		-webkit-transition: z-index .3s,
+			visibility 0s ease 0s,
+			-webkit-transform .3s ease-in-out;
+		transition: z-index .3s,
+			visibility 0s ease 0s,
+			-webkit-transform .3s ease-in-out;
+		-o-transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility 0s ease 0s;
+		transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility 0s ease 0s;
+		transition: transform .3s ease-in-out,
+			z-index .3s,
+			visibility 0s ease 0s,
+			-webkit-transform .3s ease-in-out;
 	}
 }
 

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -185,7 +185,7 @@
 
 	.js--show-search .aimeos .main-navbar .form-inline {
 		visibility: visible;
-		top: 60px;
+		top: 62px;
 		z-index: 2000;
 		transition: top .3s ease-in-out, z-index .3s, visibility 0s ease 0s;
 	}

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -47,7 +47,7 @@
 		justify-content: space-between;
 		flex-wrap: nowrap;
 		position: relative;
-		width: 30px;
+		width: 18px;
 		cursor: pointer;
 		transition: color .3s;
 	}

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -1,36 +1,18 @@
 /**
  * @license LGPLv3, http://opensource.org/licenses/LGPL-3.0
  * @copyright Aimeos (aimeos.org), 2015-2018
- */
+*/
 
 
-
-/* Footer */
-
-.aimeos .main-footer {
-	background-color: #F8F8F8;
-	position: relative;
-	left: 3rem;
-	bottom: 0;
-	margin: 0 2.5%;
-	padding: 0.25rem;
-	width: calc(95% - 3rem);
-	text-align: right;
-}
-
-@media (min-width: 992px) {
-	.aimeos .main-footer {
-		width: calc(95% - 5rem);
-		left: 5rem;
-	}
-}
-
-
-
-/* Content navigation */
+/** Content navigation **/
 
 .aimeos .main-navbar {
-	text-align: right;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	min-height: 3rem;
+
+	/* text-align: right; */
 	background-color: #F8F8F8;
 	margin-bottom: 1rem;
 	padding: 0.5rem;
@@ -48,6 +30,54 @@
 .aimeos .main-navbar .navbar-secondary:before {
 	content: " ";
 }
+
+
+/** Search Toggle **/
+
+@media (max-width: 992px) {
+	.aimeos .toggle-search {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		flex-wrap: nowrap;
+		position: relative;
+		width: 30px;
+		cursor: pointer;
+		transition: color .3s;
+	}
+
+	.aimeos .toggle-search:hover {
+		color: #333;
+	}
+
+	.aimeos .toggle-search .icon {
+		font: normal normal normal 14px/1 FontAwesome;
+		color: #90A0B0;
+		display: block;
+	}
+
+	.aimeos .toggle-search .icon.chevron {
+		font-size: 10px;
+		color: #ccc;
+	}
+
+	.aimeos .toggle-search .icon.search:before {
+		content: "\f002"
+	}
+
+	.aimeos .toggle-search .icon.chevron:before {
+		content: "\f078";
+	}
+}
+
+@media (min-width: 992px) {
+	.aimeos .toggle-search {
+		display: none;
+	}
+}
+
+
+/** Search **/
 
 .aimeos .main-navbar .input-group {
 	width: inherit;
@@ -83,7 +113,7 @@
 	content: "\f0da";
 }
 
-.aimeos .main-navbar form > * {
+.aimeos .main-navbar form>* {
 	margin-left: 0.25rem;
 }
 
@@ -106,6 +136,14 @@
 .aimeos .main-navbar .input-group {
 	display: inline-flex;
 }
+
+.aimeos .main-navbar span.placeholder {
+	display: inline-block;
+	height: 35px;
+}
+
+
+/** Content **/
 
 .aimeos .main-content .item-actions {
 	padding: 0 calc(0.5rem + 15px);
@@ -132,12 +170,13 @@
 	margin: 0;
 }
 
-.aimeos .main-content .item-actions .btn.act-help {
-	min-width: 3rem;
-}
-
 .aimeos .main-content {
 	margin-bottom: 1rem;
+	padding: 0;
+}
+
+.aimeos .main-content .item-actions .btn.act-help {
+	min-width: 3rem;
 }
 
 @media (min-width: 768px) {
@@ -147,6 +186,7 @@
 		z-index: 1041;
 		top: 0;
 	}
+
 	.aimeos .item-container .item-actions {
 		display: none;
 	}
@@ -155,5 +195,23 @@
 @media (max-width: 992px) {
 	.aimeos .main-content .item-actions .btn:not(.dropdown-toggle) {
 		min-width: 6rem;
+	}
+}
+
+
+/* Footer */
+
+.aimeos .main-footer {
+	background-color: #F8F8F8;
+	position: relative;
+	padding: 0.25rem 0.5rem;
+	text-align: right;
+	width: auto;
+	margin: auto 0 1rem 3rem;
+}
+
+@media (min-width: 992px) {
+	.aimeos .main-footer {
+		margin-left: 5rem;
 	}
 }

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -4,7 +4,7 @@
 */
 
 
-/** Content navigation **/
+/* Content navigation */
 
 .aimeos .main-navbar {
 	display: flex;
@@ -31,10 +31,16 @@
 	content: " ";
 }
 
+.aimeos .main-navbar span.placeholder {
+	display: inline-block;
+	height: 35px;
+}
+
 
 /** Search Toggle **/
 
 @media (max-width: 992px) {
+
 	.aimeos .toggle-search {
 		display: flex;
 		align-items: center;
@@ -52,21 +58,27 @@
 
 	.aimeos .toggle-search .icon {
 		font: normal normal normal 14px/1 FontAwesome;
-		color: #90A0B0;
+		color: #bdbdbd;
 		display: block;
 	}
 
 	.aimeos .toggle-search .icon.chevron {
 		font-size: 10px;
-		color: #ccc;
+		color: #4090C0;
 	}
 
 	.aimeos .toggle-search .icon.search:before {
 		content: "\f002"
 	}
 
+	/* open */
 	.aimeos .toggle-search .icon.chevron:before {
 		content: "\f078";
+	}
+
+	/* close */
+	.js--show-search .aimeos .toggle-search .icon.chevron:before {
+		content: "\f077";
 	}
 }
 
@@ -77,22 +89,10 @@
 }
 
 
-/** Search **/
+/** Search field with custom selects **/
 
-.aimeos .main-navbar .input-group {
-	width: inherit;
-}
-
-.aimeos .main-navbar input,
-.aimeos .main-navbar .custom-select,
-.aimeos .main-navbar .filter-columns .dropdown-item,
-.aimeos .main-navbar .filter-columns .dropdown-toggle {
-	font-family: monospace;
-	border-radius: 0;
-}
-
-.aimeos .main-navbar .dropdown-item input {
-	margin-right: 0.75rem;
+.aimeos .main-navbar form>* {
+	margin-left: 0.25rem;
 }
 
 .aimeos .main-navbar form .more,
@@ -113,8 +113,34 @@
 	content: "\f0da";
 }
 
-.aimeos .main-navbar form>* {
-	margin-left: 0.25rem;
+.aimeos .main-navbar .form-inline,
+.aimeos .main-navbar .input-group {
+	display: inline-flex;
+}
+
+.aimeos .main-navbar .input-group {
+	width: inherit;
+}
+
+.aimeos .main-navbar .input-group input,
+.aimeos .main-navbar .input-group select {
+	border: 1px solid #bbb;
+}
+
+.aimeos .main-navbar .input-group select {
+	height: 34px;
+}
+
+.aimeos .main-navbar input,
+.aimeos .main-navbar .custom-select,
+.aimeos .main-navbar .filter-columns .dropdown-item,
+.aimeos .main-navbar .filter-columns .dropdown-toggle {
+	font-family: monospace;
+	border-radius: 0;
+}
+
+.aimeos .main-navbar .dropdown-item input {
+	margin-right: 0.75rem;
 }
 
 .aimeos .main-navbar .filter-columns,
@@ -132,14 +158,37 @@
 	max-width: 4rem;
 }
 
-.aimeos .main-navbar .form-inline,
-.aimeos .main-navbar .input-group {
-	display: inline-flex;
-}
+@media (max-width: 992px) {
 
-.aimeos .main-navbar span.placeholder {
-	display: inline-block;
-	height: 35px;
+	.aimeos .main-navbar .form-inline {
+		flex-wrap: nowrap;
+		align-items: center;
+		justify-content: flex-end;
+		position: fixed;
+		/*
+		TODO: fixed elements don't respect the scrollbar, so its width
+		need to be included on desktops: 32px
+		*/
+		right: 15px;
+		left: calc(3rem + 15px);
+		background: white;
+		padding: 0.25rem;
+		border-radius: 4px;
+		box-shadow: 0 0 4px rgba(0, 0, 0, .35);
+		white-space: nowrap;
+
+		transition: top .3s ease-in-out, z-index .3s, visibility .3s ease .3s;
+		top: -36px;
+		z-index: -1;
+		visibility: hidden;
+	}
+
+	.js--show-search .aimeos .main-navbar .form-inline {
+		visibility: visible;
+		top: 60px;
+		z-index: 2000;
+		transition: top .3s ease-in-out, z-index .3s, visibility 0s ease 0s;
+	}
 }
 
 


### PR DESCRIPTION
The main content Area in mobile state mainly changes the horizontally scrollable content and, in the case of "product" hide the search field and adds a toggle to make it slide-in/-out from/to the top. Also, the pagination gets smaller and a mobile text variant for the current page is added.

1. The new "search toggle" currently only appears on the "product" page. It is a combination of a gray search icon and a blue chevron that changes its direction from pointing down to up once the toggle activates the search box. (Not sure if this icon combination is any good, but I had no other idea... asking for input!)
It toggles the visibility state of the search box, which is initially hidden in mobile state (actually moved to the top, outside of the visible screen).

The pagination margin of all its buttons is reduced and it shows a simpler page state text.

The "number of pages per page" selector is moved to the right simply because its dropdown expand to the right, and currently I don't know how to fix that. Personally, I think it is ok to switch the positions of the pagination and the selector... what do you think?

![mainContentArea_01](https://user-images.githubusercontent.com/213803/85207722-12499800-b32b-11ea-93dc-cf02c971f66b.jpg)

2. Once the search toggle is clicked, the search box slides in from the top and stops right over the pagination, which is most likely the one interface item that a user won't need when searching for something. So let's use that space.
The chevron of the search toggle button changes direction to indicate that it now can be clicked/touched to close the search again.

![mainContentArea_02](https://user-images.githubusercontent.com/213803/85207723-15448880-b32b-11ea-98f8-3a9b9fc30294.jpg)

The screenshots have a bit of a different table styling, but that is not implemented (yet).

Is the code formatting better?
