### PR TITLE
Tackle flickering

### DIFF
--- a/admin/jqadm/templates/common/page-standard.php
+++ b/admin/jqadm/templates/common/page-standard.php
@@ -147,7 +147,7 @@ $infoMsgs = array_merge( $this->get( 'pageInfo', [] ), $this->get( 'info', [] ) 
 <div class="aimeos" lang="<?= $this->param( 'lang' ); ?>" data-url="<?= $enc->attr( $this->url( $jsonTarget, $jsonCntl, $jsonAction, array( 'site' => $site ), [], $jsonConfig ) ); ?>">
 
 	<div class="container-fluid">
-		<div class="row">
+		<div class="row flex-nowrap">
 
 			<nav class="main-sidebar">
 				<div class="sidebar-wrapper">

--- a/admin/jqadm/themes/default/sidebar.css
+++ b/admin/jqadm/themes/default/sidebar.css
@@ -335,7 +335,6 @@
 }
 
 .aimeos .main-content {
-	margin-left: 3rem;
 	padding: 0 2.5%;
 }
 
@@ -423,14 +422,14 @@
 	.aimeos .sidebar-menu li:hover .tree-menu {
 		left: 5rem;
 	}
-
-	.aimeos .main-content {
-		margin-left: 5rem;
-	}
 }
 
 
 @media (max-width: 992px) {
+	.aimeos .main-content {
+		margin-left: 3rem;
+	}
+	
 	.js--show-nav-items-texts .aimeos .sidebar-wrapper {
 		width: 9rem;
 	}

--- a/admin/jqadm/themes/default/sidebar.css
+++ b/admin/jqadm/themes/default/sidebar.css
@@ -485,3 +485,16 @@
 		transform: rotate(90deg);
 	}
 }
+
+
+
+/* Laravel / Symphony Hack */
+
+.app-menu+.aimeos .sidebar-wrapper {
+	top: -30px;
+	min-height: calc(100vh + 30px);
+}
+
+.app-menu+.aimeos .sidebar-wrapper .logo {
+	padding-top: 15px;
+}


### PR DESCRIPTION
The new mobile layout contributions cause flickering in desktop state, because the sidebar is not equal-height with the content area.
This fix tries to solve that. Currently only tested in TYPO3, but there seems to be a distance on the top of the sidebar nav in Laravel, which I haven't setup yet. (Will do, but maybe in the meantime somebody can test on Laravel... and in general...? Thank you!)