### PR TITLE
Add / adapt / fix CSS for mobile display

### DIFF
--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -80,10 +80,6 @@
 	margin-bottom: 1.35rem;
 }
 
-.aimeos .tree-toolbar {
-	font-size: 90%;
-}
-
 .aimeos .tree-toolbar .btn {
 	font-size: initial;
 }

--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -8,40 +8,37 @@
 
 .aimeos .list-page {
 	text-align: center;
+	display: flex;
+	margin-bottom: 0.5rem;
+	justify-content: space-between;
 }
 
-.page-limit .dropdown-menu {
-	min-width: 5rem;
+.aimeos .list-page .page-limit,
+.aimeos .list-page .pagination {
+	margin: 0;
 }
 
-.page-limit .dropdown-menu .dropdown-item {
-	text-align: center
+.aimeos .list-page .btn {
+	padding-left: 0.5rem;
+	padding-right: 0.5rem;
 }
 
-@media (max-width: 992px) {
+.aimeos .list-page .page-link {
+	min-width: 2rem;
+}
 
+@media (min-width: 768px) {
 	.aimeos .list-page {
-		display: flex;
 		margin-bottom: 1rem;
-		justify-content: space-between;
-	}
-
-	.aimeos .list-page .page-limit,
-	.aimeos .list-page .pagination {
-		margin: 0;
-	}
-
-	.aimeos .list-page .btn {
-		padding-left: 0.5rem;
-		padding-right: 0.5rem;
-	}
-
-	.aimeos .list-page .page-link {
-		min-width: 2rem;
 	}
 }
 
 @media (min-width: 992px) {
+	.aimeos .list-page {
+		display: block;
+		margin-bottom: 0.5rem;
+	}
+
 	.aimeos .list-page .pagination {
 		display: inline-block;
 		margin: 1rem;
@@ -64,6 +61,14 @@
 	.aimeos .list-page .page-link {
 		min-width: 3rem;
 	}
+}
+
+.page-limit .dropdown-menu {
+	min-width: 5rem;
+}
+
+.page-limit .dropdown-menu .dropdown-item {
+	text-align: center
 }
 
 
@@ -156,7 +161,7 @@
 }
 
 .aimeos .list-items th .dropdown-toggle:focus {
-	box-shadow: 0 0 0 2px rgba(2,117,216,.25);
+	box-shadow: 0 0 0 2px rgba(2, 117, 216, .25);
 }
 
 .aimeos .list-items tr:not(.list-search) td.image {
@@ -175,28 +180,28 @@
 
 .aimeos .list-items .sort-asc:after {
 	font: normal normal normal 14px/1 FontAwesome;
-	content:" \f176";
+	content: " \f176";
 }
 
 .aimeos .list-items .sort-desc:after {
 	font: normal normal normal 14px/1 FontAwesome;
-	content:" \f175";
+	content: " \f175";
 }
 
 .aimeos .list-items .status-1:before {
-	content:"\f00c";
+	content: "\f00c";
 }
 
 .aimeos .list-items .status-0:before {
-	content:"\f00d";
+	content: "\f00d";
 }
 
 .aimeos .list-items .status--1:before {
-	content:"\f06e";
+	content: "\f06e";
 }
 
 .aimeos .list-items .status--2:before {
-	content:"\f187";
+	content: "\f187";
 }
 
 .aimeos .list-items .config-item {
@@ -216,7 +221,7 @@
 
 .aimeos .list-items a.items-field.act-view:after {
 	font: normal normal normal 14px/1 FontAwesome;
-	content:"\f06e";
+	content: "\f06e";
 }
 
 
@@ -227,7 +232,7 @@
 	font-size: 150%;
 	padding: 0.5rem 0;
 	margin-bottom: 1rem;
-	border-bottom: 1px solid rgba(0,0,0,.15);
+	border-bottom: 1px solid rgba(0, 0, 0, .15);
 }
 
 .aimeos .item-meta {
@@ -240,6 +245,10 @@
 	margin: 0.5rem;
 	font-size: 80%;
 	display: inline-block;
+}
+
+.aimeos .item-meta small {
+	margin: 0 0.5rem 0.25rem;
 }
 
 .aimeos .item-meta .meta-value {
@@ -400,7 +409,7 @@
 /** Subscription */
 
 .aimeos .item-subscription span.form-control {
-    border-color: transparent;
+	border-color: transparent;
 }
 
 .aimeos .item-subscription .interval-field {
@@ -455,12 +464,12 @@
 }
 
 .aimeos .item-order .item-product-list .column-subscription .btn-subscription:before {
-	content:"\f073";
+	content: "\f073";
 }
 
 .aimeos .item-order .item-product-list .column-status {
-    max-width: 10rem;
-    min-width: 5rem;
+	max-width: 10rem;
+	min-width: 5rem;
 }
 
 .aimeos .item-order .item-product-list .column-desc {

--- a/admin/jqadm/themes/default/bootstrap.css
+++ b/admin/jqadm/themes/default/bootstrap.css
@@ -6,7 +6,8 @@
 
 /* Fixes */
 
-html, body {
+html,
+body {
 	position: relative;
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -22,12 +23,13 @@ textarea {
 
 /* misaligned col-*-6 block in subpanels */
 .card-block.collapse.show,
-.tab-content > .row.active {
+.tab-content>.row.active {
 	display: flex;
 }
 
 /* checkbox styling */
-input[type='checkbox'], input[type='radio'] {
+input[type='checkbox'],
+input[type='radio'] {
 	margin: calc(0.5rem + 1px) 0;
 	height: 1rem;
 }
@@ -62,7 +64,19 @@ input[type='checkbox'], input[type='radio'] {
 .info-list.alert {
 	position: fixed;
 	z-index: 10000;
-	width: calc(95% - 5rem);
+	width: calc(100% - 4.5rem);
+}
+
+@media (min-width: 768px) {
+	.info-list.alert {
+		width: calc(100% - 5rem);
+	}
+}
+
+@media (min-width: 992px) {
+	.info-list.alert {
+		width: calc(100% - 8rem);
+	}
 }
 
 .btn {
@@ -80,12 +94,15 @@ input[type='checkbox'], input[type='radio'] {
 	color: #FFFFFF !important;
 }
 
-.btn-primary.focus, .btn-primary:focus {
+.btn-primary.focus,
+.btn-primary:focus {
 	box-shadow: none;
 }
 
-.btn-primary.active, .btn-primary:active,
-.btn-primary:hover, .show > .btn-primary.dropdown-toggle {
+.btn-primary.active,
+.btn-primary:active,
+.btn-primary:hover,
+.show>.btn-primary.dropdown-toggle {
 	background-color: #3080B0;
 }
 
@@ -168,7 +185,8 @@ input[type='checkbox'], input[type='radio'] {
 	border-top: 3px solid rgba(0, 0, 0, 0.125);
 }
 
-.table td, .table th {
+.table td,
+.table th {
 	border-top: none;
 }
 
@@ -192,6 +210,7 @@ td.is-invalid .form-control {
 	border: none;
 	border-radius: 0;
 	border-bottom: 1px solid #bbb;
+	font-size: inherit;
 }
 
 .form-control:focus,
@@ -201,7 +220,8 @@ td.is-invalid .form-control {
 	box-shadow: none;
 }
 
-.form-control:disabled, .form-control[readonly] {
+.form-control:disabled,
+.form-control[readonly] {
 	background-color: #f8f8f8;
 }
 
@@ -210,7 +230,8 @@ td.is-invalid .form-control {
 	justify-content: inherit;
 }
 
-.btn, .dropdown-menu {
+.btn,
+.dropdown-menu {
 	font-size: 100%;
 	z-index: 1040;
 }
@@ -233,20 +254,16 @@ td.is-invalid .form-control {
 	.aimeos {
 		font-size: 80%;
 	}
+
 	.navbar-brand {
 		font-size: 1rem;
 	}
+
 	.custom-select {
 		height: 33px;
 	}
+
 	.form-group.row .form-control-label {
 		font-size: 90%;
-	}
-}
-
-
-@media (max-width: 991px) {
-	.info-list.alert {
-		width: calc(95% - 3rem);
 	}
 }

--- a/admin/jqadm/themes/default/common.css
+++ b/admin/jqadm/themes/default/common.css
@@ -279,6 +279,10 @@
 	content: "\f0d8";
 }
 
+.aimeos .tree-toolbar .btn.fa {
+	font-size: 0.8rem;
+}
+
 @media (min-width: 768px) {
 	.aimeos .item .navbar-content {
 		position: -webkit-sticky;

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -262,15 +262,9 @@
 
 /* MQ Mobile very small only */
 
-@media (max-width: 360px) {
+@media (max-width: 400px) {
 	.aimeos .main-content .item-actions {
 		font-size: 0.7rem;
-	}
-
-	.aimeos .form-control {
-		height: calc(1.9em + 2px);
-		line-height: 1.35;
-		padding: 0.15rem 0.15rem 0.45rem;
 	}
 
 	.nav-tabs .nav-link {

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -267,6 +267,10 @@
 		font-size: 0.7rem;
 	}
 
+	.aimeos .form-control.search-input {
+		font-size: 0.8rem;
+	}
+
 	.nav-tabs .nav-link {
 		padding: 0.35rem 0.75rem;
 	}

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -8,16 +8,23 @@
 
 .aimeos .main-navbar {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	justify-content: space-between;
-	min-height: 3rem;
+	min-height: 2.5rem;
 	background-color: #F8F8F8;
-	padding: 0.5rem;
-	margin: 1rem 0;
+	padding: 0 0.5rem;
+	margin: 0.5rem 0;
 }
 
 .aimeos .main-navbar .navbar-brand {
-	float: left;
+	align-items: baseline;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 0;
+	padding-top: 0;
+	padding-bottom: 0;
 }
 
 .aimeos .main-navbar .navbar-secondary {
@@ -37,7 +44,7 @@
 
 /** Search Toggle **/
 
-@media (max-width: 992px) {
+@media (max-width: 767px) {
 
 	.aimeos .toggle-search {
 		display: flex;
@@ -69,6 +76,10 @@
 	.aimeos .toggle-search {
 		display: none;
 	}
+}
+
+.aimeos .form-control.filter-value {
+	font-size: 1rem;
 }
 
 
@@ -141,6 +152,8 @@
 	max-width: 4rem;
 }
 
+/* MQ Mobile only */
+
 @media (max-width: 767px) {
 
 	.aimeos .main-navbar .form-inline {
@@ -148,7 +161,7 @@
 		align-items: center;
 		justify-content: flex-end;
 		position: absolute;
-		right: 0;
+		right: -0.5rem;
 		left: 3rem;
 		max-width: 100%;
 		background: white;
@@ -174,17 +187,17 @@
 			z-index .3s,
 			visibility .3s ease .3s,
 			-webkit-transform .3s ease-in-out;
-		-webkit-transform: translateY(-48px);
-		-ms-transform: translateY(-48px);
-		transform: translateY(-48px);
+		-webkit-transform: translateY(-58px);
+		-ms-transform: translateY(-58px);
+		transform: translateY(-58px);
 	}
 
 	.js--show-search .aimeos .main-navbar .form-inline {
 		visibility: visible;
 		z-index: 2000;
-		-webkit-transform: translateY(58px);
-		-ms-transform: translateY(58px);
-		transform: translateY(58px);
+		-webkit-transform: translateY(45px);
+		-ms-transform: translateY(45px);
+		transform: translateY(45px);
 		-webkit-transition: z-index .3s,
 			visibility 0s ease 0s,
 			-webkit-transform .3s ease-in-out;
@@ -207,39 +220,66 @@
 
 /** Content **/
 
+.aimeos .main-content {
+	margin-left: 3rem;
+	margin-right: -0.5rem;
+	margin-bottom: 1rem;
+	padding: 0;
+}
+
 .aimeos .main-content .item-actions {
 	padding: 0 calc(0.5rem + 15px);
 	white-space: nowrap;
 	text-align: right;
-	width: 100%;
+	font-size: 0.8rem;
+	display: block;
+	width: inherit;
+	margin-left: auto;
 }
 
-.aimeos .main-navbar .item-actions {
+.aimeos .main-content .main-navbar .item-actions {
 	display: inline-block;
 	width: inherit;
 	padding: 0;
 }
 
-.aimeos .main-content .item-actions .btn:not(.dropdown-toggle) {
-	min-width: 8rem;
+.aimeos .main-content .item-actions .btn:not(.dropdown-toggle):not(.act-help) {
+	min-width: 4rem;
+}
+
+.aimeos .main-content .item-actions .btn.act-help {
+	min-width: 2rem;
+}
+
+.aimeos .main-content .item-actions .btn {
+	margin: 0;
 }
 
 .aimeos .main-content .item-actions .btn {
 	margin: 0.5rem 0;
 }
 
-.aimeos .main-navbar .item-actions .btn {
-	margin: 0;
+
+/* MQ Mobile very small only */
+
+@media (max-width: 360px) {
+	.aimeos .main-content .item-actions {
+		font-size: 0.7rem;
+	}
+
+	.aimeos .form-control {
+		height: calc(1.9em + 2px);
+		line-height: 1.35;
+		padding: 0.15rem 0.15rem 0.45rem;
+	}
+
+	.nav-tabs .nav-link {
+		padding: 0.35rem 0.75rem;
+	}
 }
 
-.aimeos .main-content {
-	margin-bottom: 1rem;
-	padding: 0;
-}
 
-.aimeos .main-content .item-actions .btn.act-help {
-	min-width: 3rem;
-}
+/* MQ Tablet+ */
 
 @media (min-width: 768px) {
 	.aimeos .main-navbar {
@@ -247,6 +287,22 @@
 		position: sticky;
 		z-index: 1041;
 		top: 0;
+		margin: 1rem 0;
+		min-height: 3rem;
+	}
+
+	.aimeos .main-navbar .item-actions {
+		margin-top: 0;
+		font-size: 90%;
+	}
+
+	.aimeos .main-content {
+		margin-left: 3.5rem;
+		margin-right: 0rem;
+	}
+
+	.aimeos .main-content .item-actions .btn:not(.dropdown-toggle):not(.act-help) {
+		min-width: 5rem;
 	}
 
 	.aimeos .item-container .item-actions {
@@ -254,8 +310,20 @@
 	}
 }
 
-@media (max-width: 992px) {
-	.aimeos .main-content .item-actions .btn:not(.dropdown-toggle) {
+
+/* MQ Desktop+ */
+
+@media (min-width: 992px) {
+
+	.aimeos .main-navbar .item-actions {
+		margin-top: 0;
+	}
+
+	.aimeos .main-content {
+		margin-left: 6rem;
+	}
+
+	.aimeos .main-content .item-actions .btn:not(.dropdown-toggle):not(.act-help) {
 		min-width: 6rem;
 	}
 }
@@ -269,11 +337,12 @@
 	padding: 0.25rem 0.5rem;
 	text-align: right;
 	width: auto;
-	margin: auto 0 1rem 3rem;
+	margin: auto -0.5rem 1rem 3rem;
 }
 
 @media (min-width: 992px) {
 	.aimeos .main-footer {
-		margin-left: 5rem;
+		margin-left: 6rem;
+		margin-right: 0;
 	}
 }

--- a/admin/jqadm/themes/default/sidebar.css
+++ b/admin/jqadm/themes/default/sidebar.css
@@ -308,7 +308,7 @@
 	position: fixed;
 	bottom: 0;
 	left: 0;
-	width: 3rem;
+	width: 3.5rem;
 	height: 2rem;
 	background: #202830;
 	border-left: 0.2rem solid transparent;

--- a/admin/jqadm/themes/default/sidebar.css
+++ b/admin/jqadm/themes/default/sidebar.css
@@ -332,22 +332,9 @@
 }
 
 
-/* Main Content */
-
-.aimeos .main-content {
-	margin-left: 3rem;
-	padding: 0 2.5%;
-}
-
-
 /* Desktop state only */
 
 @media (min-width: 992px) {
-
-	.aimeos .main-sidebar {
-		width: 6rem;
-	}
-
 	.aimeos .main-sidebar .title {
 		display: block;
 		font-size: 90%;
@@ -368,11 +355,8 @@
 	.aimeos .sidebar-menu li:hover .tree-menu-wrapper {
 		left: 6rem;
 	}
-
-	.aimeos .main-content {
-		margin-left: 6rem;
-	}
 }
+
 
 
 /* Mobile state only */
@@ -549,7 +533,52 @@
 
 /* Scrollbar styles for Firefox */
 
-.aimeos .sidebar-wrapper {
+.aimeos .main-sidebar .sidebar-wrapper {
 	scrollbar-color: rgba(64, 144, 192, 0.65) transparent;
 	scrollbar-width: thin;
+}
+
+
+/* Stretching the sidebar's height to prevent visiblity of animated tree-menu */
+
+@media (max-width: 992px) and (min-height: 790px) and (max-height:850px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 150px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 850px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 250px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 950px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 350px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 1050px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 450px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 1150px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 550px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 1250px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 650px;
+	}
+}
+
+@media (max-width: 992px) and (min-height: 1350px) {
+	.aimeos .sidebar-menu.advanced {
+		padding-bottom: 750px;
+	}
 }


### PR DESCRIPTION
Tested with TYPO3 and Laravel.

The sidebar-nav and the main-navbar are adjusted to / optimised for mobile display.

Parts of the main content area are adapted, too (like font-size, margins, general positioning of pagination, search bar and action buttons), but there are still areas that need work (will be addressed in a separate PR).