### PR TITLE
Fix filter search in newly added "vue-block"

### DIFF
--- a/admin/jqadm/templates/common/partials/navsearch-standard.php
+++ b/admin/jqadm/templates/common/partials/navsearch-standard.php
@@ -36,18 +36,18 @@ $enc = $this->encoder();
 
 
 ?>
-<div id="js--toggle-search" class="toggle-search">
+<div id="js--toggle-search" class="toggle-search" @click="toggleFilterSearchMobile">
 	<span class="icon search"></span>
-	<span class="hidden">Show/hide search.</span>
+	<span class="hidden">Button to show/hide the filter search in mobile state only.</span>
 </div>
 
 <form class="form-inline" method="POST" action="<?= $enc->attr( $this->url( $target, $controller, $action, $params, [], $config ) ); ?>">
 	<?= $this->csrf()->formfield(); ?>
 
-	<i class="fa more"></i>
+	<i class="fa" :class="toggleFilter ? 'more' : 'less'" @click="toggleFilterSearch"></i>
 
 	<div class="input-group">
-		<select class="custom-select filter-key" name="<?= $this->formparam( ['filter', 'key', '0'] ); ?>">
+		<select class="custom-select filter-key" :class="toggleFilter ? '' : 'expanded'" name="<?= $this->formparam( ['filter', 'key', '0'] ); ?>">
 			<?php foreach( $this->get( 'filterAttributes', [] ) as $code => $attrItem ) : ?>
 				<?php if( $attrItem->isPublic() ) : ?>
 					<option value="<?= $enc->attr( $code ); ?>" data-type="<?= $enc->attr( $attrItem->getType() ); ?>" <?= $selected( $filter, 'key', $code ); ?> >
@@ -56,14 +56,14 @@ $enc = $this->encoder();
 				<?php endif; ?>
 			<?php endforeach; ?>
 		</select>
-		<select class="custom-select filter-operator" name="<?= $this->formparam( ['filter', 'op', '0'] ); ?>">
+		<select class="custom-select filter-operator" :class="toggleFilter ? '' : 'expanded'" name="<?= $this->formparam( ['filter', 'op', '0'] ); ?>">
 			<?php foreach( $this->get( 'filterOperators/compare', [] ) as $code ) : ?>
 				<option value="<?= $enc->attr( $code ); ?>" <?= $selected( $filter, 'op', $code ); ?> >
 					<?= $enc->html( $code ) . ( strlen( $code ) === 1 ? '&nbsp;' : '' ); ?>&nbsp;&nbsp;<?= $enc->html( $this->translate( 'admin/ext', $code ) ); ?>
 				</option>
 			<?php endforeach; ?>
 		</select>
-		<input type="text" class="form-control filter-value" name="<?= $this->formparam( ['filter', 'val', '0'] ); ?>"
+		<input type="text" class="form-control filter-value" ref="input-filter-value" name="<?= $this->formparam( ['filter', 'val', '0'] ); ?>"
 			 value="<?= $enc->attr( ( isset( $filter['val'][0] ) ? $filter['val'][0] : '' ) ); ?>" >
 		<div class="input-group-append">
 			<button class="btn btn-primary fa fa-search"></button>

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -509,7 +509,6 @@ Aimeos.Filter = {
 
 		this.selectDDInput();
 		this.setupFilterOperators();
-		this.toggleSearch();
 	},
 
 
@@ -567,22 +566,6 @@ Aimeos.Filter = {
 			var type = $(":selected", this).data("type");
 
 			Aimeos.Filter.selectFilterOperator(select, type);
-		});
-	},
-
-
-	toggleSearch : function() {
-
-		$(".aimeos .main-navbar form").on("click", ".more", function(ev) {
-			$(".filter-columns,.filter-key,.filter-operator", ev.delegateTarget).toggle(300, function() {
-				$(ev.currentTarget).removeClass("more").addClass("less");
-			});
-		});
-
-		$(".aimeos .main-navbar form").on("click", ".less", function(ev) {
-			$(".filter-columns,.filter-key,.filter-operator", ev.delegateTarget).toggle(300, function() {
-				$(ev.currentTarget).removeClass("less").addClass("more");
-			});
 		});
 	}
 };
@@ -1121,11 +1104,19 @@ $(function() {
 
 		Aimeos.components[key] = new Vue({
 			el: this,
-			data: {data: null},
+			data: function() {
+				return {
+					data: null,
+					toggleFilter: true,
+				}
+			},
 			beforeMount: function() {
 				if(this.$el.dataset && this.$el.dataset.data) {
 					this.data = JSON.parse(this.$el.dataset.data);
 				}
+			},
+			mounted: function() {
+				this.clearFilterValue()
 			},
 			methods: {
 				add: function(data) {
@@ -1133,6 +1124,15 @@ $(function() {
 				},
 				remove: function(idx) {
 					this.$refs[key].remove(idx);
+				},
+				toggleFilterSearch: function () {
+					this.toggleFilter = !this.toggleFilter
+				},
+				toggleFilterSearchMobile: function () {
+					document.body.classList.toggle('js--show-search');
+				},
+				clearFilterValue: function () {
+					this.$refs['input-filter-value'].value = ''
 				}
 			}
 		});

--- a/admin/jqadm/themes/default/nav.css
+++ b/admin/jqadm/themes/default/nav.css
@@ -140,16 +140,34 @@
 .aimeos .main-navbar .filter-columns,
 .aimeos .main-navbar .filter-operator,
 .aimeos .main-navbar .filter-key {
+	opacity: 0;
 	display: none;
-	max-width: 9rem;
+	overflow: hidden;
+	transition: all 0.25s;
 }
 
 .aimeos .main-navbar .filter-value {
-	max-width: 9rem;
+	width: 9rem;
+	overflow: hidden;
 }
 
+.aimeos .main-navbar .filter-key,
 .aimeos .main-navbar .filter-operator {
-	max-width: 4rem;
+	width: 0;
+}
+
+.aimeos .main-navbar .filter-key.expanded {
+	width: 9rem;
+}
+
+.aimeos .main-navbar .filter-operator.expanded {
+	width: 4rem;
+}
+
+.aimeos .main-navbar .filter-key.expanded,
+.aimeos .main-navbar .filter-operator.expanded {
+	opacity: 1;
+	display: inline-block;
 }
 
 /* MQ Mobile only */

--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -110,7 +110,7 @@ Vue.component('config-table', {
 	},
 
 	methods: {
-		add : function() {
+		add: function() {
 			let list = this.items;
 			list.push({key: '', val: ''});
 			this.$emit('update:config', list);


### PR DESCRIPTION
I do not know, why vue does not like the jquery manipulations of the search filter bar, since there are no reactive elements that vue managers.

This PR moves the click functionality to Vue and removes the "toggleSearch" function that was handled by jquery in the`Aimeos.Filter` object.

It also adds a function that clears the input field after reload. I do not know if this is a welcome feature (I personally do not like it, because I prefer to see what I actually was looking for).

Furthermore, the animation got lost that took place when the fields opened or closed. They where handled by jquery. I tried to imitate them using CSS, but it is impossible to hide a `select` DOM elements completely with CSS visibility and opacity rules only (the arrows of those boxes remain visible). Using `display: none` is not satisfying, since the immediate switch to "display: [inline-]block" causes a jump.

This solution was tested in Laravel only so far. Help wanted for TYPO3 9 and TYPO3 10 - thank you!