### PR TITLE
Index does not contains serviceId, use getServiceId from object

### DIFF
--- a/admin/jqadm/src/Admin/JQAdm/Order/Standard.php
+++ b/admin/jqadm/src/Admin/JQAdm/Order/Standard.php
@@ -545,14 +545,14 @@ class Standard
 
 		foreach( $basket->getServices() as $type => $services )
 		{
-			foreach( $services as $serviceId => $service )
+			foreach( $services as $index => $service )
 			{
 				$list = [];
 				$attrItems = $service->getAttributeItems();
 
-				if( isset( $data['service'][$type][$serviceId] ) )
+				if( isset( $data['service'][$type][$service->getServiceId()] ) )
 				{
-					foreach( (array) $data['service'][$type][$serviceId] as $key => $pair )
+					foreach( (array) $data['service'][$type][$service->getServiceId()] as $key => $pair )
 					{
 						foreach( $pair as $pos => $value ) {
 							$list[$pos][$key] = $value;


### PR DESCRIPTION
This fixes the issue in: https://aimeos.org/help/viewtopic.php?f=18&t=3079

Saving an order would remove all code/value pairs from the services payment and delivery.