### PR TITLE
Fix the product url, which does not accept underscores.

### DIFF
--- a/admin/jqadm/src/Admin/JQAdm/Product/Standard.php
+++ b/admin/jqadm/src/Admin/JQAdm/Product/Standard.php
@@ -484,7 +484,7 @@ class Standard
 		{
 			$data['product.siteid'] = $this->getContext()->getLocale()->getSiteId();
 			$data['product.code'] = $data['product.code'] . '_copy';
-			$data['product.url'] = $data['product.url'] . '_' . time();
+			$data['product.url'] = $data['product.url'] . '-' . time();
 			$data['product.id'] = '';
 		}
 


### PR DESCRIPTION
Hi everybody.

Our last pull request was kind of . . . . shitty.

The product url segment does not work with underscores.
We are not really sure, why this worked in the first place.
But, we can not make the underscore work in a vanilla shop (or our modified wip anymore).
So much for QA.

Anyway, we are sorry for this.

Holger and Tobi