### PR TITLE
Change/add editor config options.

### DIFF
--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -23,7 +23,7 @@ Aimeos = {
 
 	extraPlugins: 'divarea',
 
-	removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
+	removeButtons: 'Underline,Subscript,Superscript',
 
 	flatpickr : {
 		datetimerange: {

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -19,7 +19,11 @@ Aimeos = {
 		{ name: 'document', items: [ 'Source' ] }
 	],
 
-	editortags : 'div(*);span(*);p(*);',
+  editortags : 'div(*);span(*);p(*);',
+
+  extraPlugins: 'devarea',
+
+  removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
 
 	flatpickr : {
 		datetimerange: {

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -21,9 +21,9 @@ Aimeos = {
 
 	editortags : 'div(*);span(*);p(*);',
 
-	extraPlugins: 'divarea',
+	editorExtraPlugins: 'divarea',
 
-	removeButtons: 'Underline,Subscript,Superscript',
+	editorRemoveButtons: 'Underline,Subscript,Superscript',
 
 	flatpickr : {
 		datetimerange: {

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -19,11 +19,11 @@ Aimeos = {
 		{ name: 'document', items: [ 'Source' ] }
 	],
 
-  editortags : 'div(*);span(*);p(*);',
+	editortags : 'div(*);span(*);p(*);',
 
-  extraPlugins: 'devarea',
+	extraPlugins: 'devarea',
 
-  removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
+	removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
 
 	flatpickr : {
 		datetimerange: {

--- a/admin/jqadm/themes/admin.js
+++ b/admin/jqadm/themes/admin.js
@@ -21,7 +21,7 @@ Aimeos = {
 
 	editortags : 'div(*);span(*);p(*);',
 
-	extraPlugins: 'devarea',
+	extraPlugins: 'divarea',
 
 	removeButtons: 'Superscript,Subscript,JustifyBlock,Underline',
 

--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -158,13 +158,13 @@ Vue.component('html-editor', {
 		this.instance = CKEDITOR.replace(this.id, {
 			extraAllowedContent: Aimeos.editortags,
 			toolbar: Aimeos.editorcfg,
-			extraPlugins: Aimeos.extraPlugins,
+			extraPlugins: Aimeos.editorExtraPlugins,
 			initialData: this.value,
 			readOnly: this.readonly,
 			protectedSource: [/\n/g],
 			autoParagraph: false,
 			entities: false,
-			removeButtons: Aimeos.removeButtons
+			removeButtons: Aimeos.editorRemoveButtons
 		});
 		this.instance.on('change', this.change);
 	},

--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -158,12 +158,13 @@ Vue.component('html-editor', {
 		this.instance = CKEDITOR.replace(this.id, {
 			extraAllowedContent: Aimeos.editortags,
 			toolbar: Aimeos.editorcfg,
-			extraPlugins: 'divarea',
+			extraPlugins: Aimeos.extraPlugins,
 			initialData: this.value,
 			readOnly: this.readonly,
 			protectedSource: [/\n/g],
 			autoParagraph: false,
-			entities: false
+      entities: false,
+      removeButtons: Aimeos.removeButtons
 		});
 		this.instance.on('change', this.change);
 	},

--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -163,8 +163,8 @@ Vue.component('html-editor', {
 			readOnly: this.readonly,
 			protectedSource: [/\n/g],
 			autoParagraph: false,
-      entities: false,
-      removeButtons: Aimeos.removeButtons
+			entities: false,
+			removeButtons: Aimeos.removeButtons
 		});
 		this.instance.on('change', this.change);
 	},


### PR DESCRIPTION
Add a `removeButtons` option and change `editortags` and `extraPlugins` config options, so users can override them. 

Necessary, because *CKEditor Standard Edition v4* (jsdelivr fetches from npm, which send a "standard all" edition) comes with all non-community plugins deactivated and a "removeButtons" setting  (undocumented which buttons are removed by default). But things like text align require plugins to be activated respectively `Subscript` or `Superscript` require certain buttons to be set to visible.

Along with this PR comes a new chapter "customize" in the *Aimeos* "Admin/JQAdm backend" documentation.

