### PR TITLE
Add rules to CKEditor to prevent the addition of white-space on "save".

### DIFF
--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -156,18 +156,18 @@ Vue.component('html-editor', {
 
 	mounted: function() {
 		this.instance = CKEDITOR.replace(this.id, {
-      on: {
-        instanceReady: function( ev ) {
-          this.dataProcessor.writer.setRules( 'br', {
-            breakBeforeOpen: false,
-            breakAfterClose: false
-          });
-          this.dataProcessor.writer.setRules( 'p', {
-            breakBeforeOpen: false,
-            breakAfterClose: false
-          });
-        }
-      },
+			on: {
+				instanceReady: function( ev ) {
+					this.dataProcessor.writer.setRules( 'br', {
+					breakBeforeOpen: false,
+					breakAfterClose: false
+				});
+					this.dataProcessor.writer.setRules( 'p', {
+					breakBeforeOpen: false,
+					breakAfterClose: false
+				});
+				}
+			},
 			extraAllowedContent: Aimeos.editortags,
 			toolbar: Aimeos.editorcfg,
 			extraPlugins: Aimeos.editorExtraPlugins,

--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -156,6 +156,18 @@ Vue.component('html-editor', {
 
 	mounted: function() {
 		this.instance = CKEDITOR.replace(this.id, {
+      on: {
+        instanceReady: function( ev ) {
+          this.dataProcessor.writer.setRules( 'br', {
+            breakBeforeOpen: false,
+            breakAfterClose: false
+          });
+          this.dataProcessor.writer.setRules( 'p', {
+            breakBeforeOpen: false,
+            breakAfterClose: false
+          });
+        }
+      },
 			extraAllowedContent: Aimeos.editortags,
 			toolbar: Aimeos.editorcfg,
 			extraPlugins: Aimeos.editorExtraPlugins,


### PR DESCRIPTION
Issue: https://github.com/aimeos/ai-admin-jqadm/issues/151
CKEditor documentation: https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_htmlWriter.html#method-setRules

Currently, CKEditor appends "\n" to "br" and "p" (and probably others that I didn't test) tags on each save action and on each CKEditor instance on a page. Even though they do not disturb the HTML output (layout-wise), they quickly sum up and generate huge white space areas, which are annoying when debugging.

The new options prevent CKEditor 4 in doing so. 
(Note: CKEditor 5 handles this topic in a different way.)