### PR TITLE
Fix ckeditor configuration to suppress addition of whitespace on save.

### DIFF
--- a/admin/jqadm/themes/vue-components.js
+++ b/admin/jqadm/themes/vue-components.js
@@ -157,13 +157,19 @@ Vue.component('html-editor', {
 	mounted: function() {
 		this.instance = CKEDITOR.replace(this.id, {
 			on: {
-				instanceReady: function( ev ) {
+				instanceReady: function() {
 					this.dataProcessor.writer.setRules( 'br', {
+					indent: false,
 					breakBeforeOpen: false,
+					breakAfterOpen: false,
+					breakBeforeClose: false,
 					breakAfterClose: false
 				});
 					this.dataProcessor.writer.setRules( 'p', {
+					indent: false,
 					breakBeforeOpen: false,
+					breakAfterOpen: false,
+					breakBeforeClose: false,
 					breakAfterClose: false
 				});
 				}


### PR DESCRIPTION
The configuration to suppress the addition of whitespace-on-save consists of 5 parameters. I initially thought that overriding only those parameters that are required to achieve the intended behaviour would suffice, but that seems to be wrong.
Instead, **all** parameters (5) must be added.

Also, the parameter "ev" is not required in this case and therefore removed.
