### PR TITLE
Make close button darker.

### DIFF
--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -220,6 +220,10 @@
 	content: "\f06e";
 }
 
+.aimeos table .list-item-new .actions .btn.act-close {
+	color:rgb(152, 160, 176);
+}
+
 
 
 /* Detail view */

--- a/admin/jqadm/themes/default/admin.css
+++ b/admin/jqadm/themes/default/admin.css
@@ -221,7 +221,7 @@
 }
 
 .aimeos table .list-item-new .actions .btn.act-close {
-	color:rgb(152, 160, 176);
+	color:#98a0b0;
 }
 
 


### PR DESCRIPTION
When adding a product to a category/supplier/customer, the close/remove button is hard to see due to the light background. This PR assigns the appropriate dark color of such buttons.

![Aimeos-remove-btn-darker](https://user-images.githubusercontent.com/213803/99701885-5afdac80-2a95-11eb-980d-687d3730db22.jpg)
