### PR TITLE
Fix customer country select not holding value

### DIFF
--- a/admin/jqadm/templates/customer/item-standard.php
+++ b/admin/jqadm/templates/customer/item-standard.php
@@ -332,16 +332,15 @@ $params = $this->get( 'pageParams', [] );
 					<div class="form-group row mandatory">
 						<label class="col-sm-4 form-control-label help"><?= $enc->html( $this->translate( 'admin', 'Country' ) ); ?></label>
 						<div class="col-sm-8">
-							<select class="form-control item-countryid" required="required" tabindex="<?= $this->get( 'tabindex' ) ?>"
-								v-bind:name="`<?= $enc->attr( $this->formparam( array( 'address', 'idx', 'customer.countryid' ) ) ) ?>`.replace('idx', idx)"
-								v-bind:readonly="items[idx]['customer.siteid'] != siteid"
-								v-model="items[idx]['customer.countryid']" />
+							<select class="form-control item-countryid" required="required" tabindex="1"
+								name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.countryid' ) ) ) ?>"
+								<?= $this->site()->readonly( $this->get( 'itemData/customer.siteid' ) ) ?> >
 								<option value="" disabled>
 									<?= $enc->html( $this->translate( 'admin', 'Please select' ) ) ?>
 								</option>
 
 								<?php foreach( $this->get( 'countries', [] ) as $code => $label ) : ?>
-									<option value="<?= $enc->attr( $code ) ?>" >
+									<option value="<?= $enc->attr( $code ) ?>" <?= $selected( $this->get( 'itemData/customer.countryid' ), $code ) ?> >
 										<?= $enc->html( $label ) ?>
 									</option>
 								<?php endforeach ?>


### PR DESCRIPTION
There was conversation in the forum regarding a patch made to the country select here.

https://aimeos.org/help/viewtopic.php?f=16&t=3995#p16244

It appears there could be a problem with this update, it seem the HTML may have been copied the template `item-address-standard`, this is dynamic as the admins can create multiple addresses on a customer. As a result, the vue syntax is not being rendered, which results in the select list not having a name and the value never be stored for the customer.

Additionally it's also missing the option to select the current selected option in the list with the helper `$selected` in the file.

This update is working for me, it holds the value and does what is intended.