### PR TITLE
Update default light / dark theme handling

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -3,12 +3,14 @@
  * @copyright Aimeos (aimeos.org), 2015-2022
  */
 
-
 /* Check for preferred theme mode (dark/light) */
-
 const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
-if (prefersDark.matches && !document.cookie.includes('aimeos_backend_theme=light')) {
-	['light', 'dark'].map(cl => document.body.classList.toggle(cl));
+const setLight = document.cookie.includes('aimeos_backend_theme=light');
+
+//Light by default (based on View used) - checks for Dark preference (by browser, or cookie)
+if (prefersDark.matches && !setLight){
+	document.body.classList.remove('light');
+	document.body.classList.add('dark')
 }
 
 document.querySelectorAll(".btn-theme").forEach(item => {


### PR DESCRIPTION
Updated approach for setting the default light / dark theme to explicitly remove the "light", and add the "dark", class to the body element. Theme is set to "light" by default based on cookie presence / contents.

Note: Previous approach would revert to light theme when browser was set to dark in the applications preferences.