### PR TITLE
Update list.php

### DIFF
--- a/templates/admin/jqadm/customer/list.php
+++ b/templates/admin/jqadm/customer/list.php
@@ -721,7 +721,7 @@ $columnList = [
 								<?php if( $this->access( ['super', 'admin'] ) && !$this->site()->readonly( $item->getSiteId() ) ) : ?>
 									<a class="btn act-delete fa" tabindex="1"
 										v-on:click.prevent.stop="askDelete(`<?= $enc->js( $id ) ?>`, $event)"
-										href="<?= $enc->attr( $this->link( 'admin/jqadm/url/delete', $params ) ) ?>"
+										href="<?= $enc->attr( $this->link( 'admin/jqadm/url/delete', ['id' => $id] + $params ) ) ?>"
 										title="<?= $enc->attr( $this->translate( 'admin', 'Delete this entry' ) ) ?>"
 										aria-label="<?= $enc->attr( $this->translate( 'admin', 'Delete' ) ) ?>">
 									</a>


### PR DESCRIPTION
Currently the delete links do not work on the customer listing page. This small commit fixes this by adding the id parameter to the links.