### PR TITLE
Use inclusive date range in flatpickr selection

### DIFF
--- a/admin/jqadm/js/admin.js
+++ b/admin/jqadm/js/admin.js
@@ -87,7 +87,16 @@ Aimeos = {
 			},
 			mode: "range",
 			position: 'below',
-			wrap: false
+			wrap: false,
+			dateFormat: "Y-m-d H:i:S",
+			onChange: function (selectedDates, datestr) {
+				if( typeof selectedDates[1] !== 'undefined' ) {
+					selectedDates[1].setHours( 23 );
+					selectedDates[1].setMinutes( 59 );
+					selectedDates[1].setSeconds( 59 );
+					this.setDate([ selectedDates[0], selectedDates[1] ]);
+				}
+			}
 		},
 		date: {
 			altInput: true,


### PR DESCRIPTION
Currently, when selecting a date range e.g. in the orders list, the "to" date is only used until "YYYY-MM-DD 00:00:00". This is very confusing and leads to wrong exports. Extending the flatpickr configuration for "daterange" objects to consider the chosen "to"-date until "23:59:59" o'clock seems to be the minimal invasive way to make the date range behaviour intuitive.