### PR TITLE
Fix missing required prop: value in FlatPickr

### DIFF
--- a/templates/admin/jqadm/customer/list.php
+++ b/templates/admin/jqadm/customer/list.php
@@ -416,14 +416,14 @@ $columnList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.birthday' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/customer.birthday')"
-                                                        v-bind:config="Aimeos.flatpickr.date"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.birthday' ) ) ?>`"
-                                                    >
+													    is="flat-pickr"
+													    class="form-control"
+													    type="date"
+													    name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.birthday' ) ) ) ?>"
+													    v-bind:disabled="state('item/customer.birthday')"
+													    v-bind:config="Aimeos.flatpickr.date"
+													    v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.birthday' ) ) ?>`"
+													>
 												</div>
 											</div>
 										</div>

--- a/templates/admin/jqadm/customer/list.php
+++ b/templates/admin/jqadm/customer/list.php
@@ -287,10 +287,15 @@ $columnList = [
 													<?= $enc->html( $this->translate( 'admin', 'Verified' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-															name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.dateverified' ) ) ) ?>"
-															v-bind:disabled="state('item/customer.dateverified')"
-															v-bind:config="Aimeos.flatpickr.date">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.dateverified' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/customer.dateverified')"
+                                                        v-bind:config="Aimeos.flatpickr.date"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.dateverified' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 										</div>
@@ -410,10 +415,15 @@ $columnList = [
 													<?= $enc->html( $this->translate( 'admin', 'Birthday' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-														name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.birthday' ) ) ) ?>"
-														v-bind:disabled="state('item/customer.birthday')"
-														v-bind:config="Aimeos.flatpickr.date">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.birthday' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/customer.birthday')"
+                                                        v-bind:config="Aimeos.flatpickr.date"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.birthday' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 										</div>

--- a/templates/admin/jqadm/customer/list.php
+++ b/templates/admin/jqadm/customer/list.php
@@ -288,14 +288,14 @@ $columnList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.dateverified' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/customer.dateverified')"
-                                                        v-bind:config="Aimeos.flatpickr.date"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.dateverified' ) ) ?>`"
-                                                    >
+													    is="flat-pickr"
+													    class="form-control"
+													    type="date"
+													    name="<?= $enc->attr( $this->formparam( array( 'item', 'customer.dateverified' ) ) ) ?>"
+													    v-bind:disabled="state('item/customer.dateverified')"
+													    v-bind:config="Aimeos.flatpickr.date"
+													    v-bind:value="`<?= $enc->js( $this->get( 'itemData/customer.dateverified' ) ) ?>`"
+													>
 												</div>
 											</div>
 										</div>

--- a/templates/admin/jqadm/order/list.php
+++ b/templates/admin/jqadm/order/list.php
@@ -420,14 +420,14 @@ $statusList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datepayment' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/order.datepayment')"
-                                                        v-bind:config="Aimeos.flatpickr.date"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datepayment' ) ) ?>`"
-                                                    >
+													   is="flat-pickr"
+													   class="form-control"
+													   type="date"
+													   name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datepayment' ) ) ) ?>"
+													   v-bind:disabled="state('item/order.datepayment')"
+													   v-bind:config="Aimeos.flatpickr.date"
+													   v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datepayment' ) ) ?>`"
+													 >
 												</div>
 											</div>
 											<div class="row">
@@ -476,14 +476,14 @@ $statusList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datedelivery' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/order.datedelivery')"
-                                                        v-bind:config="Aimeos.flatpickr.date"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datedelivery' ) ) ?>`"
-                                                    >
+                                                        						   is="flat-pickr"
+                                                        						   class="form-control"
+													   type="date"
+													   name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datedelivery' ) ) ) ?>"
+													   v-bind:disabled="state('item/order.datedelivery')"
+													   v-bind:config="Aimeos.flatpickr.date"
+													   v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datedelivery' ) ) ?>`"
+                                                    							 >
 												</div>
 											</div>
 											<div class="row">

--- a/templates/admin/jqadm/order/list.php
+++ b/templates/admin/jqadm/order/list.php
@@ -419,10 +419,15 @@ $statusList = [
 													<?= $enc->html( $this->translate( 'admin', 'Pay date' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-														name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datepayment' ) ) ) ?>"
-														v-bind:disabled="state('item/order.datepayment')"
-														v-bind:config="Aimeos.flatpickr.date">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datepayment' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/order.datepayment')"
+                                                        v-bind:config="Aimeos.flatpickr.date"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datepayment' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 											<div class="row">
@@ -470,10 +475,15 @@ $statusList = [
 													<?= $enc->html( $this->translate( 'admin', 'Ship date' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-														name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datedelivery' ) ) ) ?>"
-														v-bind:disabled="state('item/order.datedelivery')"
-														v-bind:config="Aimeos.flatpickr.date">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'order.datedelivery' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/order.datedelivery')"
+                                                        v-bind:config="Aimeos.flatpickr.date"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/order.datedelivery' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 											<div class="row">

--- a/templates/admin/jqadm/service/list.php
+++ b/templates/admin/jqadm/service/list.php
@@ -230,14 +230,14 @@ $columnList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'service.datestart' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/service.datestart')"
-                                                        v-bind:config="Aimeos.flatpickr.datetime"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.datestart' ) ) ?>`"
-                                                    >
+													   is="flat-pickr"
+													   class="form-control"
+													   type="date"
+													   name="<?= $enc->attr( $this->formparam( array( 'item', 'service.datestart' ) ) ) ?>"
+													   v-bind:disabled="state('item/service.datestart')"
+													   v-bind:config="Aimeos.flatpickr.datetime"
+													   v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.datestart' ) ) ?>`"
+													>
 												</div>
 											</div>
 											<div class="row">
@@ -249,14 +249,14 @@ $columnList = [
 												</label>
 												<div class="col-7">
 													<input
-                                                        is="flat-pickr"
-                                                        class="form-control"
-                                                        type="date"
-                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'service.dateend' ) ) ) ?>"
-                                                        v-bind:disabled="state('item/service.dateend')"
-                                                        v-bind:config="Aimeos.flatpickr.datetime"
-                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.dateend' ) ) ?>`"
-                                                    >
+													   is="flat-pickr"
+													   class="form-control"
+													   type="date"
+													   name="<?= $enc->attr( $this->formparam( array( 'item', 'service.dateend' ) ) ) ?>"
+													   v-bind:disabled="state('item/service.dateend')"
+													   v-bind:config="Aimeos.flatpickr.datetime"
+													   v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.dateend' ) ) ?>`"
+													>
 												</div>
 											</div>
 										</div>

--- a/templates/admin/jqadm/service/list.php
+++ b/templates/admin/jqadm/service/list.php
@@ -229,10 +229,15 @@ $columnList = [
 													<?= $enc->html( $this->translate( 'admin', 'Start date' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-														name="<?= $enc->attr( $this->formparam( array( 'item', 'service.datestart' ) ) ) ?>"
-														v-bind:disabled="state('item/service.datestart')"
-														v-bind:config="Aimeos.flatpickr.datetime">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'service.datestart' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/service.datestart')"
+                                                        v-bind:config="Aimeos.flatpickr.datetime"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.datestart' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 											<div class="row">
@@ -243,10 +248,15 @@ $columnList = [
 													<?= $enc->html( $this->translate( 'admin', 'End date' ) ) ?>
 												</label>
 												<div class="col-7">
-													<input is="flat-pickr" class="form-control" type="date"
-														name="<?= $enc->attr( $this->formparam( array( 'item', 'service.dateend' ) ) ) ?>"
-														v-bind:disabled="state('item/service.dateend')"
-														v-bind:config="Aimeos.flatpickr.datetime">
+													<input
+                                                        is="flat-pickr"
+                                                        class="form-control"
+                                                        type="date"
+                                                        name="<?= $enc->attr( $this->formparam( array( 'item', 'service.dateend' ) ) ) ?>"
+                                                        v-bind:disabled="state('item/service.dateend')"
+                                                        v-bind:config="Aimeos.flatpickr.datetime"
+                                                        v-bind:value="`<?= $enc->js( $this->get( 'itemData/service.dateend' ) ) ?>`"
+                                                    >
 												</div>
 											</div>
 										</div>


### PR DESCRIPTION
In some lists, the required prop: "value" is not being passed to the FlatPickr component:
![image](https://user-images.githubusercontent.com/42222569/214493493-e200c953-68ae-458f-b578-1c5647716fa8.png)
