### PR TITLE
Hide input number arrows

### DIFF
--- a/themes/default/common.css
+++ b/themes/default/common.css
@@ -805,3 +805,13 @@ body {
 	--ck-color-input-disabled-text: var(--bs-secondary-light, #90A8C0);
 	--ck-z-modal: 1050;
 }
+
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type=number] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
This commit makes the up/down arrows on <input type="number"> elements hidden by default. This provides a cleaner default look for number inputs.
[![Jq52OWx.md.png](https://iili.io/Jq52OWx.md.png)](https://freeimage.host/i/Jq52OWx)