### PR TITLE
Add parentid filter to coupon codes

### DIFF
--- a/js/coupon.js
+++ b/js/coupon.js
@@ -118,6 +118,7 @@ Aimeos.Coupon.Code = {
 		beforeMount() {
 			this.Aimeos = Aimeos;
 			this.order = 'coupon.code.id';
+			this.filter['coupon.code.parentid'] = {'==': {'coupon.code.parentid': this.parentid}};
 
 			const fieldkey = 'aimeos/jqadm/couponcode/fields';
 			this.fieldlist = this.columns(this.fields || [], fieldkey);


### PR DESCRIPTION
Fixed a problem where coupon code parentid filter is missing, which caused coupon items to display coupon codes from other coupon items.