### PR TITLE
Make dashboard chart/toplist widgets idempotent

### DIFF
--- a/js/dashboard-order.js
+++ b/js/dashboard-order.js
@@ -26,6 +26,13 @@ Aimeos.Dashboard.Order = {
 		if(!canvas) {
 			throw "Unable to create canvas for " + selector + " .chart canvas";
 		}
+
+		Chart.getChart(canvas)?.destroy();
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+
 		return canvas.getContext('2d');
 	},
 
@@ -33,18 +40,6 @@ Aimeos.Dashboard.Order = {
 	done(selector) {
 		document.querySelectorAll(selector + ' .loading').forEach(function(el) {
 			el.classList.remove('loading');
-		});
-	},
-
-
-	start(selector) {
-		const canvas = document.querySelector(selector + ' .chart canvas');
-		if(canvas) {
-			Chart.getChart(canvas)?.destroy();
-		}
-
-		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
-			el.classList.add('loading');
 		});
 	},
 
@@ -73,7 +68,6 @@ Aimeos.Dashboard.Order = {
 	chartDay() {
 
 		const self = this;
-		this.start('.order-countday');
 		const ctx = this.context('.order-countday');
 
 		const cellWidth = this.dayCellSize + 4;
@@ -200,7 +194,6 @@ Aimeos.Dashboard.Order = {
 	chartHour() {
 
 		const self = this;
-		this.start('.order-counthour');
 		const keys = "order.chour";
 		const ctx = this.context('.order-counthour');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');
@@ -293,7 +286,6 @@ Aimeos.Dashboard.Order = {
 	chartPaymentStatus() {
 
 		const self = this;
-		this.start('.order-countpaystatus');
 		const ctx = this.context('.order-countpaystatus');
 		const keys = ["order.statuspayment", "order.cdate"];
 		const labels = JSON.parse(document.querySelector('.order-countpaystatus').dataset.labels) || {};
@@ -411,7 +403,6 @@ Aimeos.Dashboard.Order = {
 	chartCountry() {
 
 		const self = this;
-		this.start('.order-countcountry');
 		const keys = "order.address.countryid";
 		const ctx = this.context('.order-countcountry');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');

--- a/js/dashboard-order.js
+++ b/js/dashboard-order.js
@@ -37,6 +37,18 @@ Aimeos.Dashboard.Order = {
 	},
 
 
+	start(selector) {
+		const canvas = document.querySelector(selector + ' .chart canvas');
+		if(canvas) {
+			Chart.getChart(canvas)?.destroy();
+		}
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+	},
+
+
 	gradient(color, alpha, ctx) {
 		const gradient = ctx.createLinearGradient(0,0 , 0,280);
 
@@ -61,6 +73,7 @@ Aimeos.Dashboard.Order = {
 	chartDay() {
 
 		const self = this;
+		this.start('.order-countday');
 		const ctx = this.context('.order-countday');
 
 		const cellWidth = this.dayCellSize + 4;
@@ -187,6 +200,7 @@ Aimeos.Dashboard.Order = {
 	chartHour() {
 
 		const self = this;
+		this.start('.order-counthour');
 		const keys = "order.chour";
 		const ctx = this.context('.order-counthour');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');
@@ -279,6 +293,7 @@ Aimeos.Dashboard.Order = {
 	chartPaymentStatus() {
 
 		const self = this;
+		this.start('.order-countpaystatus');
 		const ctx = this.context('.order-countpaystatus');
 		const keys = ["order.statuspayment", "order.cdate"];
 		const labels = JSON.parse(document.querySelector('.order-countpaystatus').dataset.labels) || {};
@@ -396,6 +411,7 @@ Aimeos.Dashboard.Order = {
 	chartCountry() {
 
 		const self = this;
+		this.start('.order-countcountry');
 		const keys = "order.address.countryid";
 		const ctx = this.context('.order-countcountry');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');
@@ -456,6 +472,7 @@ Aimeos.Dashboard.Order = {
 			const toplist = document.querySelector('.order-countcountry .toplist');
 
 			if(toplist) {
+				toplist.innerHTML = '';
 				list.sort((a, b) => b.val - a.val);
 
 				for(const entry of list.slice(0, self.topLimit)) {

--- a/js/dashboard-sales.js
+++ b/js/dashboard-sales.js
@@ -81,6 +81,18 @@ Aimeos.Dashboard.Sales = {
 	},
 
 
+	start(selector) {
+		const canvas = document.querySelector(selector + ' .chart canvas');
+		if(canvas) {
+			Chart.getChart(canvas)?.destroy();
+		}
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+	},
+
+
 	gradient(ctx, index) {
 		const gradient = ctx.createLinearGradient(0,0 , 0,280);
 
@@ -123,6 +135,7 @@ Aimeos.Dashboard.Sales = {
 	chartDay() {
 
 		const self = this;
+		this.start('.order-salesday');
 		const ctx = this.context('.order-salesday');
 		const keys = ["order.currencyid", "order.cdate"];
 		const startdate = moment().utc().startOf('day').subtract(30, 'days');
@@ -188,6 +201,7 @@ Aimeos.Dashboard.Sales = {
 	chartMonth() {
 
 		const self = this;
+		this.start('.order-salesmonth');
 		const ctx = this.context('.order-salesmonth');
 		const keys = ["order.currencyid", "order.cmonth"];
 		const startdate = moment().utc().startOf('month').subtract(12, 'months');
@@ -256,6 +270,7 @@ Aimeos.Dashboard.Sales = {
 	chartWeekday() {
 
 		const self = this;
+		this.start('.order-salesweekday');
 		const ctx = this.context('.order-salesweekday');
 		const keys = ["order.currencyid", "order.cwday"];
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');

--- a/js/dashboard-sales.js
+++ b/js/dashboard-sales.js
@@ -70,6 +70,13 @@ Aimeos.Dashboard.Sales = {
 		if(!canvas) {
 			throw "Unable to create canvas for " + selector + " .chart canvas";
 		}
+
+		Chart.getChart(canvas)?.destroy();
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+
 		return canvas.getContext('2d');
 	},
 
@@ -77,18 +84,6 @@ Aimeos.Dashboard.Sales = {
 	done(selector) {
 		document.querySelectorAll(selector + ' .loading').forEach(function(el) {
 			el.classList.remove('loading');
-		});
-	},
-
-
-	start(selector) {
-		const canvas = document.querySelector(selector + ' .chart canvas');
-		if(canvas) {
-			Chart.getChart(canvas)?.destroy();
-		}
-
-		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
-			el.classList.add('loading');
 		});
 	},
 
@@ -135,7 +130,6 @@ Aimeos.Dashboard.Sales = {
 	chartDay() {
 
 		const self = this;
-		this.start('.order-salesday');
 		const ctx = this.context('.order-salesday');
 		const keys = ["order.currencyid", "order.cdate"];
 		const startdate = moment().utc().startOf('day').subtract(30, 'days');
@@ -201,7 +195,6 @@ Aimeos.Dashboard.Sales = {
 	chartMonth() {
 
 		const self = this;
-		this.start('.order-salesmonth');
 		const ctx = this.context('.order-salesmonth');
 		const keys = ["order.currencyid", "order.cmonth"];
 		const startdate = moment().utc().startOf('month').subtract(12, 'months');
@@ -270,7 +263,6 @@ Aimeos.Dashboard.Sales = {
 	chartWeekday() {
 
 		const self = this;
-		this.start('.order-salesweekday');
 		const ctx = this.context('.order-salesweekday');
 		const keys = ["order.currencyid", "order.cwday"];
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');

--- a/js/dashboard-service.js
+++ b/js/dashboard-service.js
@@ -23,6 +23,13 @@ Aimeos.Dashboard.Service = {
 		if(!canvas) {
 			throw "Unable to create canvas for " + selector + " .chart canvas";
 		}
+
+		Chart.getChart(canvas)?.destroy();
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+
 		return canvas.getContext('2d');
 	},
 
@@ -30,18 +37,6 @@ Aimeos.Dashboard.Service = {
 	done(selector) {
 		document.querySelectorAll(selector + ' .loading').forEach(function(el) {
 			el.classList.remove('loading');
-		});
-	},
-
-
-	start(selector) {
-		const canvas = document.querySelector(selector + ' .chart canvas');
-		if(canvas) {
-			Chart.getChart(canvas)?.destroy();
-		}
-
-		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
-			el.classList.add('loading');
 		});
 	},
 
@@ -78,7 +73,6 @@ Aimeos.Dashboard.Service = {
 	chartDelivery() {
 
 		const self = this;
-		this.start('.order-servicedelivery');
 		const keys = "order.service.code";
 		const ctx = this.context('.order-servicedelivery');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');
@@ -147,7 +141,6 @@ Aimeos.Dashboard.Service = {
 	chartPayment() {
 
 		const self = this;
-		this.start('.order-servicepayment');
 		const keys = "order.service.code";
 		const ctx = this.context('.order-servicepayment');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');

--- a/js/dashboard-service.js
+++ b/js/dashboard-service.js
@@ -34,6 +34,18 @@ Aimeos.Dashboard.Service = {
 	},
 
 
+	start(selector) {
+		const canvas = document.querySelector(selector + ' .chart canvas');
+		if(canvas) {
+			Chart.getChart(canvas)?.destroy();
+		}
+
+		document.querySelectorAll(selector + ' .chart, ' + selector + ' .content').forEach(function(el) {
+			el.classList.add('loading');
+		});
+	},
+
+
 	gradient(alpha, context) {
 		const chartArea = context.chart.chartArea;
 		const ctx = context.chart.ctx;
@@ -66,6 +78,7 @@ Aimeos.Dashboard.Service = {
 	chartDelivery() {
 
 		const self = this;
+		this.start('.order-servicedelivery');
 		const keys = "order.service.code";
 		const ctx = this.context('.order-servicedelivery');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');
@@ -134,6 +147,7 @@ Aimeos.Dashboard.Service = {
 	chartPayment() {
 
 		const self = this;
+		this.start('.order-servicepayment');
 		const keys = "order.service.code";
 		const ctx = this.context('.order-servicepayment');
 		const startdate = moment().utc().startOf('day').subtract(12, 'months');


### PR DESCRIPTION
Each chart method in dashboard-order.js, dashboard-sales.js and dashboard-service.js previously assumed it ran exactly once at page load. Re-running them — for example from an external dashboard-filter component that re-fetches data on filter change — failed for three reasons:

1. The previous Chart.js instance was never destroyed, so a second call on the same canvas threw "Canvas is already in use".
2. chartCountry() appended <tr> rows to .order-countcountry .toplist without clearing it first, so each re-run doubled the row count.
3. The .loading class was only ever removed (via done()), never re-added; the templates pre-rendered it once at SSR time and there was no path back into the loading state.

Adds a small start(selector) helper to each module, mirroring the existing done(selector). It is called at the top of every chart method and:

- destroys any existing Chart.js instance on the widget canvas via Chart.getChart(canvas)?.destroy();
- re-applies the .loading class to "selector .chart, selector .content".

chartCountry() additionally clears its toplist innerHTML before appending fresh rows.

Existing first-run behavior is unchanged.