### PR TITLE
Fix PHP 8 array_sum() warning on string values in fromArray()

### DIFF
--- a/src/Admin/JQAdm/Order/Transaction/Standard.php
+++ b/src/Admin/JQAdm/Order/Transaction/Standard.php
@@ -230,7 +230,7 @@ class Standard
 
 		foreach( $data as $serviceId => $entry )
 		{
-			if( array_sum( (array) $entry ) === 0 || ( $service = $services->get( $serviceId ) ) === null ) {
+			if( array_sum( array_map( 'floatval', (array) $entry ) ) === 0 || ( $service = $services->get( $serviceId ) ) === null ) {
 				continue;
 			}
 


### PR DESCRIPTION
PHP 8 emits a warning when array_sum() encounters string values. The $entry array contains price values as strings (e.g. '12.50'), causing repeated warnings in the TYPO3 backend log.

Cast values to float before summing to avoid the warning while preserving the zero-check behaviour.