### PR TITLE
Fix strict comparison causing refund to trigger on empty transaction …

### DIFF
--- a/src/Admin/JQAdm/Order/Transaction/Standard.php
+++ b/src/Admin/JQAdm/Order/Transaction/Standard.php
@@ -230,7 +230,7 @@ class Standard
 
 		foreach( $data as $serviceId => $entry )
 		{
-			if( array_sum( array_map( 'floatval', (array) $entry ) ) === 0 || ( $service = $services->get( $serviceId ) ) === null ) {
+			if( array_sum( array_map( 'floatval', (array) $entry ) ) == 0 || ( $service = $services->get( $serviceId ) ) === null ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Fix: strict comparison `=== 0` causes unintended refunds on every backend save

### What happened

PR #313 introduced `array_map('floatval', ...)` before `array_sum()` to avoid
the PHP 8 `E_WARNING` on string values. This was correct. However, the
comparison was left as `=== 0` (strict), which is where I made a mistake I
should have caught before submitting.

`array_sum()` on an array of `float` values returns `float(0)`, not `int(0)`.
In PHP, `0.0 === 0` evaluates to `false` because strict comparison requires
both value and type to match. As a result, the guard condition never fired —
`continue` was never reached — and `provider->refund()` was called on every
backend save, regardless of whether the refund form fields contained any values.

### Concrete effect in production

Every time a PayPal Express order was opened and saved in the Aimeos backend
— even without making any changes — the following happened:

1. The transaction form submitted empty `value` and `costs` fields
2. `fromArray()` built a `$entry` array of empty strings
3. `array_sum(array_map('floatval', $entry))` returned `float(0)`
4. `float(0) === 0` evaluated to `false` → guard did not fire
5. `provider->refund()` was called
6. A real `RefundTransaction` API call was made to PayPal
7. Payment status was overwritten from `PAY_RECEIVED (6)` to `PAY_REFUND (3)`

This means every backend save of a PayPal Express order triggered an actual
refund API call. In a sandbox environment this corrupts order state; in
production it would issue real refunds.

### Fix

Change `=== 0` to `== 0` (loose comparison) so that `float(0)` correctly
matches and the guard fires as intended for empty form submissions.

### Apology

I apologise for not catching this before submitting #313. The type mismatch
between `float(0)` and `int(0)` under strict comparison is exactly the kind
of subtle issue that should have been part of my own initial review. It was only
discovered after deploying and observing the continued incorrect behaviour in
a test environment. I should have tested more thoroughly before submitting.